### PR TITLE
Implement fullType.

### DIFF
--- a/test/wrapped.js
+++ b/test/wrapped.js
@@ -38,7 +38,9 @@ test('can create a wrapped error', function t(assert) {
         host: 'localhost',
         name: 'ServerListenFailedError',
         causeMessage: 'listen EADDRINUSE',
-        code: 'EADDRINUSE'
+        origMessage: 'listen EADDRINUSE',
+        code: 'EADDRINUSE',
+        fullType: 'server.listen-failed~error.wrapped-unknown'
     }));
 
     assert.end();
@@ -93,9 +95,11 @@ test('can wrap real IO errors', function t(assert) {
             host: 'localhost',
             name: 'ServerListenFailedError',
             causeMessage: 'listen EADDRINUSE',
+            origMessage: 'listen EADDRINUSE',
             code: 'EADDRINUSE',
             errno: 'EADDRINUSE',
-            syscall: 'listen'
+            syscall: 'listen',
+            fullType: 'server.listen-failed~error.wrapped-io.listen.EADDRINUSE'
         }));
 
         assert.end();

--- a/test/wrapped.js
+++ b/test/wrapped.js
@@ -40,7 +40,7 @@ test('can create a wrapped error', function t(assert) {
         causeMessage: 'listen EADDRINUSE',
         origMessage: 'listen EADDRINUSE',
         code: 'EADDRINUSE',
-        fullType: 'server.listen-failed~error.wrapped-unknown'
+        fullType: 'server.listen-failed~!~error.wrapped-unknown'
     }));
 
     assert.end();
@@ -99,7 +99,8 @@ test('can wrap real IO errors', function t(assert) {
             code: 'EADDRINUSE',
             errno: 'EADDRINUSE',
             syscall: 'listen',
-            fullType: 'server.listen-failed~error.wrapped-io.listen.EADDRINUSE'
+            fullType: 'server.listen-failed~!~' +
+                'error.wrapped-io.listen.EADDRINUSE'
         }));
 
         assert.end();

--- a/wrapped.js
+++ b/wrapped.js
@@ -17,6 +17,8 @@ function WrappedError(options) {
         'WrappedError: cause field is reserved');
     assert(!has(options, 'causeMessage'),
         'WrappedError: causeMessage field is reserved');
+    assert(!has(options, 'origMessage'),
+        'WrappedError: origMessage field is reserved');
 
     var createTypedError = TypedError(options);
 
@@ -28,7 +30,8 @@ function WrappedError(options) {
             'WrappedError: first argument must be an error');
 
         var err = createTypedError(extend(opts, {
-            causeMessage: cause.message
+            causeMessage: cause.message,
+            origMessage: cause.message
         }));
 
         if (has(cause, 'code') && !has(err, 'code')) {

--- a/wrapped.js
+++ b/wrapped.js
@@ -68,7 +68,7 @@ function WrappedError(options) {
             causeType = 'error.wrapped-unknown';
         }
 
-        err.fullType = err.type + '~' +
+        err.fullType = err.type + '~!~' +
             (err.cause.type || causeType);
 
         return err;


### PR DESCRIPTION
This adds a fullType. If the originally wrapped error
is a node error we infer an original type from the
syscall & errno.

cc: @kriskowal