### PR TITLE
use util.isError() to properly detect assert errors

### DIFF
--- a/test/wrapped.js
+++ b/test/wrapped.js
@@ -180,3 +180,18 @@ test('can wrap real IO errors', function t(assert) {
         assert.end();
     }
 });
+
+test('can wrap assert errors', function t(assert) {
+  var TestError = WrappedError({
+      message: 'error: {origMessage}',
+      type: 'error'
+  });
+
+  var assertError;
+  try { require('assert').equal('a', 'b'); }
+  catch (_err) { assertError = _err; }
+
+  var err = TestError(assertError);
+  assert.equal(err.cause.actual, 'a');
+  assert.end();
+})

--- a/wrapped.js
+++ b/wrapped.js
@@ -2,6 +2,7 @@
 
 var extend = require('xtend/mutable');
 var assert = require('assert');
+var util = require('util');
 
 var TypedError = require('./typed.js');
 
@@ -101,5 +102,5 @@ function has(obj, key) {
 }
 
 function isError(err) {
-    return objectToString.call(err) === ERROR_TYPE;
+    return util.isError(err) || objectToString.call(err) === ERROR_TYPE;
 }


### PR DESCRIPTION
WrappedError does not currently accept errors originating from the native `assert` module, apparently because they are stringified as `[object Object]` rather than `[object Error]`.

This patch fixes that by using the built-in `util.isError()` to detect error objects. This is done in addition to the previous check being performed, to avoid breaking backward compatibility (though, the tests appear to pass even when just `util.isError()` is used, so it might be okay to remove the fallback. let me know if that's preferable).