### PR TITLE
Fix v7.1.0 regression

### DIFF
--- a/extend.js
+++ b/extend.js
@@ -1,0 +1,14 @@
+// NOTE: we can't use "use strict" here
+// otherwise we can't do "extend(fn, { length: null })"
+
+module.exports = extend;
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function extend(target, source) {
+    for (var key in source) {
+        if (hasOwnProperty.call(source, key)) {
+            target[key] = source[key]
+        }
+    }
+}

--- a/test/typed.js
+++ b/test/typed.js
@@ -47,3 +47,18 @@ test('a client error', function t(assert) {
 
     assert.end();
 });
+
+test('check specific "length" field', (assert) => {
+    var ServerError = TypedError({
+        type: 'myError',
+        message: 'myError',
+        length: null,
+    });
+
+    var error = ServerError();
+
+    assert.equal(ServerError.type, 'myError');
+    assert.equal(error.type, 'myError');
+
+    assert.end();
+});

--- a/typed.js
+++ b/typed.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var template = require('string-template');
+var extend = require('./extend');
 var assert = require('assert');
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
 var isWordBoundary = /[_.-](\w|$)/g;
 
 module.exports = TypedError;
@@ -56,14 +56,6 @@ function TypedError(args) {
         }
 
         return result;
-    }
-}
-
-function extend(target, source) {
-    for (var key in source) {
-        if (hasOwnProperty.call(source, key)) {
-            target[key] = source[key]
-        }
     }
 }
 

--- a/wrapped.js
+++ b/wrapped.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var extend = require('./extend');
 var util = require('util');
 
 var TypedError = require('./typed.js');
@@ -9,7 +10,6 @@ var objectToString = Object.prototype.toString;
 var ERROR_TYPE = '[object Error]';
 var causeMessageRegex = /\{causeMessage\}/g;
 var origMessageRegex = /\{origMessage\}/g;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 module.exports = WrappedError;
 
@@ -105,12 +105,4 @@ function has(obj, key) {
 
 function isError(err) {
     return util.isError(err) || objectToString.call(err) === ERROR_TYPE;
-}
-
-function extend(target, source) {
-    for (var key in source) {
-        if (hasOwnProperty.call(source, key)) {
-            target[key] = source[key]
-        }
-    }
 }


### PR DESCRIPTION
This code works with 7.0.x and broken in 7.1.0

```
var TypedError = require('../typed.js');
TypedError({
   type: 'myError',
   message: 'myError',
   length: null,
});
```

Reason: v7.0.x uses xtend package which not use 'use strict'.

I've found this because this bug affects `jaeger-client-node` which depends on `bufrw`.
jaeger-client-node -> tchannel, thriftrw -> bufrw -> error
https://github.com/uber/bufrw/blob/master/errors.js#L121
