### PR TITLE
Fix regression for WrappedError

### DIFF
--- a/test/wrapped.js
+++ b/test/wrapped.js
@@ -7,6 +7,7 @@ var WrappedError = require('../wrapped.js');
 
 test('can create a wrapped error', function t(assert) {
     var ServerListenError = WrappedError({
+        name: 'SomeError',
         message: 'server: {causeMessage}',
         type: 'server.listen-failed',
         requestedPort: null,

--- a/wrapped.js
+++ b/wrapped.js
@@ -11,6 +11,8 @@ var causeMessageRegex = /\{causeMessage\}/g;
 var origMessageRegex = /\{origMessage\}/g;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
+var FUNCTION_FIELD_WHITELIST = Object.getOwnPropertyNames(WrappedError)
+
 module.exports = WrappedError;
 
 function WrappedError(options) {
@@ -27,8 +29,14 @@ function WrappedError(options) {
     assert(!has(options, 'origMessage'),
         'WrappedError: origMessage field is reserved');
 
+    var copyArgs = {}
+    extend(copyArgs, options)
+    for (var i = 0; i < FUNCTION_FIELD_WHITELIST.length; i++) {
+        delete copyArgs[FUNCTION_FIELD_WHITELIST[i]]
+    }
+
     var createTypedError = TypedError(options);
-    extend(createError, options);
+    extend(createError, copyArgs);
     createError._name = options.name;
 
     return createError;


### PR DESCRIPTION
I believe this regression was introduced in [7.1.0](https://github.com/Raynos/error/commit/036e71dd33c2602d636d79a5b2476cf128360fe3 ) by replacing `xtend` and fixed for TypedError in [7.2.0](https://github.com/Raynos/error/commit/331434c0977eae32a213c76f97371fb067eedeca)

I've copied the code for TypedError over to WrappedError to mitigate the same issue as described in https://github.com/Raynos/error/issues/15