### PR TITLE
Modernize package.json license

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
     "@types/node": "13.13.4",
     "npm-bin-deps": "1.8.2"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Raynos/error/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "check": "npr tsc -p .",
     "lint": "npr tsdocstandard -v",


### PR DESCRIPTION
I was auditing our dependency licenses and this dependency shows up as being unlicensed

![image](https://user-images.githubusercontent.com/133747/159550611-b9652e8c-3ba9-4783-aaeb-05ddb5c795ca.png)

---

Turns out the license metadata on this is no longer a supported format
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license

> Some old packages used license objects or a "licenses" property containing an array of license objects:
> ```
> // Not valid metadata
> {
>   "license" : {
>     "type" : "ISC",
>     "url" : "https://opensource.org/licenses/ISC"
>   }
> }
> ```

