### PR TITLE
Recognize Error instances even if they don't toString as [object Error]

### DIFF
--- a/index.js
+++ b/index.js
@@ -456,6 +456,8 @@ function getInfoForPlainError (cause) {
  */
 function isError (err) {
   return Object.prototype.toString.call(err) === '[object Error]'
+    ? true
+    : err instanceof Error
 }
 
 /**


### PR DESCRIPTION
Errors thrown by Axios were failing this check for me, because they toStringed as [object Object], even though AxiosError extends Error.

Observed on Node 18.7.0, with the latest version of Axios.